### PR TITLE
PutUint64 should use <<32-1 instead of <<31-1

### DIFF
--- a/varuint.go
+++ b/varuint.go
@@ -42,7 +42,7 @@ func PutUint64(b []byte, v uint64) int {
 		b[3] = byte(v)
 		return 4
 	}
-	if v <= 1<<31-1 {
+	if v <= 1<<32-1 {
 		b[0] = 251
 		b[1] = byte(v >> 24)
 		b[2] = byte(v >> 16)

--- a/varuint_test.go
+++ b/varuint_test.go
@@ -7,7 +7,10 @@
 
 package varuint
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func testUint64(t *testing.T, x uint64) {
 	var tmp [MaxUint64Len]byte
@@ -79,6 +82,27 @@ func BenchmarkUint64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, v := range buf {
 			Uint64(v)
+		}
+	}
+}
+
+func TestIssue1Putuint64Shift(t *testing.T) {
+	tests := []struct {
+		val    uint64
+		bytes  int
+		varint []byte
+	}{
+		{2147483648, 5, []byte{0xFB, 0x80, 0x00, 0x00, 0x00}},
+	}
+	for _, test := range tests {
+		tmp := make([]byte, 9)
+		n := PutUint64(tmp, test.val)
+		if n != test.bytes {
+			t.Errorf("got %d; want %d", n, test.bytes)
+			continue
+		}
+		if !bytes.Equal(tmp[0:n], test.varint) {
+			t.Errorf("got %v want %v", tmp[0:n], test.varint)
 		}
 	}
 }


### PR DESCRIPTION
This fixes https://github.com/dchest/varuint/issues/1.

2147483648 (2^31) now encodes as `0xFB 0x80 0x00 0x00 0x00`.  Previously it was encoded as `0xFC 0x00 0x80 0x00 0x00 0x00`

A test was added for this as TestIssue1Putuint64Shift.  Current tests did not detect this issue.
